### PR TITLE
Resolved issue #16, where Description was not being picked up from <proxyname>.xml

### DIFF
--- a/src/main/java/io/apigee/buildTools/enterprise4g/utils/PackageConfigurer.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/utils/PackageConfigurer.java
@@ -153,28 +153,22 @@ public class PackageConfigurer {
 
         javax.xml.xpath.XPathFactory factory = javax.xml.xpath.XPathFactory.newInstance();
         javax.xml.xpath.XPath xpath = factory.newXPath();
-
         javax.xml.xpath.XPathExpression expression = xpath.compile("/APIProxy/Description");
 
         NodeList nodes = (NodeList) expression.evaluate(xmlDoc,
                 XPathConstants.NODESET);
 
-        if (nodes.item(0).hasChildNodes()){
-            String orginialText = "";
-            orginialText = nodes.item(0).getTextContent();
-            nodes.item(0).setTextContent(getComment(fileList.get(0))+" ::"+orginialText);
-
-        }
-        else {
+        if (nodes.item(0).hasChildNodes()) {
+            // sets the description to whatever is in the <proxyname>.xml file
+            nodes.item(0).setTextContent(expression.evaluate(xmlDoc));
+        } else {
+            // if Description is empty, then it reverts back to appending the username, git hash, etc
             nodes.item(0).setTextContent(getComment(fileList.get(0)));
         }
-
 
         DOMSource source = new DOMSource(xmlDoc);
         StreamResult result = new StreamResult(fileList.get(0));
         transformer.transform(source, result);
-
-
     }
 
     public static Document replaceTokens(Document doc, Policy configTokens)


### PR DESCRIPTION
Resolves the issue where the Description is not picked up from the <proxyname>.xml file. This now will display on Apigee Edge whatever is in the Description tags. 

If there are no Description tags, it bombs. This may be another issue to look into. I tested it with the changes I made as well as the existing plugin, both had the same behavior.
If the Description tags are present, but there is nothing in them, it will revert back to the previous behavior, with the username, git hash, etc.
