### PR TITLE
Fixes #25 by changing the DeployMojo to execute on the install phase.

### DIFF
--- a/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/DeployMojo.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/DeployMojo.java
@@ -29,9 +29,8 @@ import java.io.IOException;
 /**                                                                                                                                     ¡¡
  * Goal to upload 4g gateway  bundle on server
  * @author rmishra
- * @execute phase="package"
  * @goal deploy
- * @phase package
+ * @phase install
  * 
  */
 


### PR DESCRIPTION
```mvn package``` - this will configure/zip the bundle

```mvn install``` - this will deploy the bundle

if you configure the POM file to have both executions like below:

````
<plugin>
   <groupId>io.apigee.build-tools.enterprise4g</groupId>
   <artifactId>apigee-edge-maven-plugin</artifactId>
   <version>1.0.0</version>
   <executions>
      <execution>
         <id>configure-bundle</id>
         <phase>package</phase>
         <goals>
            <goal>configure</goal>
         </goals>
      </execution>
      <execution>
         <id>deploy-bundle</id>
         <phase>install</phase>
         <goals>
            <goal>deploy</goal>
         </goals>
      </execution>
   </executions>
</plugin>
````  

then ```mvn install``` will execute both the package and install phases, doing the configure and deploy (ideal scenario). 