### PR TITLE
Fix NullPointerException if proxy Description is missing

### DIFF
--- a/src/main/java/io/apigee/buildTools/enterprise4g/utils/PackageConfigurer.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/utils/PackageConfigurer.java
@@ -31,6 +31,7 @@ import javax.xml.xpath.XPathExpressionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import io.apigee.buildTools.enterprise4g.utils.ConfigTokens.Policy;
@@ -155,15 +156,17 @@ public class PackageConfigurer {
         javax.xml.xpath.XPath xpath = factory.newXPath();
         javax.xml.xpath.XPathExpression expression = xpath.compile("/APIProxy/Description");
 
-        NodeList nodes = (NodeList) expression.evaluate(xmlDoc,
-                XPathConstants.NODESET);
+        Node node = (Node) expression.evaluate(xmlDoc, XPathConstants.NODE);
+        if (node == null) {
+            node = xmlDoc.createElement("Description");
+        }
 
-        if (nodes.item(0).hasChildNodes()) {
+        if (node.hasChildNodes()) {
             // sets the description to whatever is in the <proxyname>.xml file
-            nodes.item(0).setTextContent(expression.evaluate(xmlDoc));
+            node.setTextContent(expression.evaluate(xmlDoc));
         } else {
             // if Description is empty, then it reverts back to appending the username, git hash, etc
-            nodes.item(0).setTextContent(getComment(fileList.get(0)));
+            node.setTextContent(getComment(fileList.get(0)));
         }
 
         DOMSource source = new DOMSource(xmlDoc);

--- a/src/test/java/io/apigee/buildTools/enterprise4g/utils/PackageConfigurerTest.java
+++ b/src/test/java/io/apigee/buildTools/enterprise4g/utils/PackageConfigurerTest.java
@@ -1,0 +1,23 @@
+package io.apigee.buildTools.enterprise4g.utils;
+
+import junit.framework.TestCase;
+import org.w3c.dom.Document;
+
+import java.io.*;
+
+public class PackageConfigurerTest extends TestCase {
+
+    private FileReader fileReader = new FileReader();
+
+    public void testConfigurePackage() throws Exception {
+        File configFile = new File(getClass().getClassLoader().getResource("configTest/config.json").toURI());
+        PackageConfigurer.configurePackage("test", configFile);
+
+        File policyFile = new File(getClass().getClassLoader().getResource("configTest/target/apiproxy/policies/QuotaPolicy.xml").toURI());
+        Document xmlDocument = fileReader.getXMLDocument(policyFile);
+
+        javax.xml.xpath.XPathFactory factory = javax.xml.xpath.XPathFactory.newInstance();
+        javax.xml.xpath.XPath xpath = factory.newXPath();
+        assertEquals("2", xpath.evaluate("/Quota/Interval", xmlDocument));
+    }
+}

--- a/src/test/resources/configTest/config.json
+++ b/src/test/resources/configTest/config.json
@@ -1,0 +1,20 @@
+{
+    "configurations": [
+        {
+            "name": "test",
+            "policies": [
+                {
+                    "name": "QuotaPolicy.xml",
+                    "tokens": [
+                        {
+                            "xpath": "/Quota/Interval",
+                            "value": "2"
+                        }
+                    ]
+                }
+            ],
+            "proxies": [ ],
+            "targets": [ ]
+        }
+    ]
+}

--- a/src/test/resources/configTest/target/apiproxy/policies/QuotaPolicy.xml
+++ b/src/test/resources/configTest/target/apiproxy/policies/QuotaPolicy.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Quota enabled="true" continueOnError="false" async="false" name="QuotaPolicy">
+    <FaultRules/>
+    <Properties/>
+    <Allow count="20"/>
+    <Interval>1</Interval>
+    <TimeUnit>minute</TimeUnit>
+</Quota>

--- a/src/test/resources/configTest/target/apiproxy/proxies/proxy.xml
+++ b/src/test/resources/configTest/target/apiproxy/proxies/proxy.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ProxyEndpoint name="proxy">
+    <Description>Devices</Description>
+    <FaultRules/>
+    <Flows>
+    </Flows>
+    <PostFlow>
+        <Request/>
+        <Response/>
+    </PostFlow>
+    <PreFlow>
+        <Request>
+            <Step>
+                <FaultRules/>
+                <Name>QuotaPolicy</Name>
+            </Step>
+        </Request>
+        <Response/>
+    </PreFlow>
+    <Statistics>
+        <EnableAll>true</EnableAll>
+    </Statistics>
+    <HTTPProxyConnection>
+        <BasePath>/createtask</BasePath>
+        <Properties/>
+        <VirtualHost>default</VirtualHost>
+    </HTTPProxyConnection>
+    <RouteRule name="default">
+        <URL>http://www.example.com/api</URL>
+    </RouteRule>
+</ProxyEndpoint>

--- a/src/test/resources/configTest/target/apiproxy/taskservice.xml
+++ b/src/test/resources/configTest/target/apiproxy/taskservice.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<APIProxy revision="76" name="taskservice">
+    <ConfigurationVersion minorVersion="0" majorVersion="4"/>
+    <CreatedAt>1389090682052</CreatedAt>
+    <CreatedBy>sdey@apigee.com</CreatedBy>
+    <DisplayName>taskservice</DisplayName>
+    <LastModifiedAt>1389090682052</LastModifiedAt>
+    <LastModifiedBy>sdey@apigee.com</LastModifiedBy>
+    <Policies>
+        <Policy>QuotaPolicy</Policy>
+    </Policies>
+    <ProxyEndpoints>
+        <ProxyEndpoint>proxy</ProxyEndpoint>
+    </ProxyEndpoints>
+    <Resources/>
+    <TargetServers/>
+    <TargetEndpoints/>
+</APIProxy>


### PR DESCRIPTION
This fixes a NullPointerException which occurs when the main proxy XML
file is missing its Description tag

Fixes #35
