### PR TITLE
Updating DeployMojo so execution will be skipped when the <skip> property is set (similar to ConfigureMojo)

### DIFF
--- a/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/DeployMojo.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/DeployMojo.java
@@ -258,6 +258,12 @@ public class DeployMojo extends GatewayAbstractMojo
 	 */
 	public void execute() throws MojoExecutionException, MojoFailureException {
 
+
+		if (super.isSkip()) {
+			getLog().info("Skipping");
+			return;
+		}
+
 		try {
 			fixOSXNonProxyHosts();
 			


### PR DESCRIPTION
ConfigureMojo currently has the ability to skip execution based on the <skip> property defined in GatewayAbstractMojo.

This functionality is also desirable in DeployMojo.

This change allows execution to be skipped via the <skip> property.
