### PR TITLE
Fix for #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,18 @@ Provide the token when invoking the plugin.
 
     mvn install -Ptest -Dusername=$ae_username -Dpassword=$ae_password \
                         -Dorg=testmyapi -Dauthtype=oauth -Dmfatoken=123456
+                        
+If the API takes a long time to package up then  it is likely that the token till have expired before it is used.  To mitigate against this, from version 1.1.3, an initmfa goal can be called during the validate phase:
+
+    <execution>
+        <id>initialise-mfa</id>
+        <phase>validate</phase>
+        <goals>
+            <goal>initmfa</goal>
+        </goals>
+    </execution>
+
+Depending on where the plugin is in the order, and how much validation is requird, it is possible that this may still result in token timeout.
 
 ## Deploying API Proxies with Node.js apps
 

--- a/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/InitMfaMojo.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/InitMfaMojo.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2014 Apigee Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apigee.buildTools.enterprise4g.mavenplugin;
+
+import io.apigee.buildTools.enterprise4g.rest.RestUtil;
+import io.apigee.buildTools.enterprise4g.rest.RestUtil.Options;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+
+
+/**
+ * Goal to initialise multifactor authentication / oauth token
+ * @author dpickard
+ * @execute phase="validate"
+ * @goal initmfa
+ * @phase validate
+ * 
+ */
+
+public class InitMfaMojo extends GatewayAbstractMojo
+{
+	
+	public InitMfaMojo() {
+		super();
+
+	}
+	
+	/** 
+	 * Entry point for the mojo.
+	 */
+	public void execute() throws MojoExecutionException, MojoFailureException {
+
+		try {
+			RestUtil.initMfa(this.getProfile());
+		} catch (RuntimeException e) {
+			throw new MojoExecutionException("", e);
+		} catch (Exception e) {
+			throw new MojoExecutionException("", e);
+		} finally {
+			
+		}
+	}
+
+}

--- a/src/main/java/io/apigee/buildTools/enterprise4g/rest/RestUtil.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/rest/RestUtil.java
@@ -240,6 +240,39 @@ public class RestUtil {
                 }
             });
 
+    public static void initMfa(ServerProfile profile) throws IOException {
+
+    	// any simple get request can be used to - we just need to get an access token
+    	// whilst the mfatoken is still valid
+    	
+        // trying to construct the URL like
+        // https://api.enterprise.apigee.com/v1/organizations/apigee-cs/apis/taskservice/
+        // success response is ignored
+    	if (accessToken == null) {
+			logger.info("=============Initialising MFA================");
+	
+	        HttpRequest restRequest = REQUEST_FACTORY
+	                .buildGetRequest(new GenericUrl(profile.getHostUrl() + "/"
+	                        + profile.getApi_version() + "/organizations/"
+	                        + profile.getOrg() + "/apis/"
+	                        + profile.getApplication() + "/"));
+	        restRequest.setReadTimeout(0);
+	        HttpHeaders headers = new HttpHeaders();
+	        headers.setAccept("application/json");
+	        restRequest.setHeaders(headers);
+	
+	        try {
+	            HttpResponse response = executeAPI(profile, restRequest);            
+	            //ignore response - we just wanted the MFA initialised
+	            logger.info("=============MFA Initialised================");
+	        } catch (HttpResponseException e) {
+	            logger.error(e.getMessage());
+	            //throw error as there is no point in continuing
+	            throw e;
+	        }
+    	}
+    }
+
     public static void getRevision(ServerProfile profile) throws IOException {
 
         // trying to construct the URL like


### PR DESCRIPTION
Added new initmfa goal that can be called during validate phase of build.  It makes a basic request to the Mgmt API so that the oauth token is initialised before the major project build work is undertaken.  This hugely reduces the likelihood of the token expiring before it is used.