### PR TITLE
Refresh Token Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,16 @@ Provide the token when invoking the plugin.
 
     mvn install -Ptest -Dusername=$ae_username -Dpassword=$ae_password \
                         -Dorg=testmyapi -Dauthtype=oauth -Dbearer=c912eu1201c
+                        
+### Passing the Refresh Token as a parameter
+If you would like to generate the refresh token outside of this plugin and provide it as a command line parameter, you can add the following: 
+
+    <apigee.refresh>${refresh}</apigee.refresh>
+
+Provide the token when invoking the plugin.
+
+    mvn install -Ptest -Dusername=$ae_username -Dpassword=$ae_password \
+                        -Dorg=testmyapi -Dauthtype=oauth -Drefresh=d023fv2312d
 
 ## Deploying API Proxies with Node.js apps
 

--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,14 @@
             <groupId>cglib</groupId>
             <artifactId>cglib</artifactId>
             <version>2.2.2</version>
-        </dependency>        
+        </dependency>       
+        
+        <dependency>
+   		 	<groupId>com.auth0</groupId>
+    		<artifactId>java-jwt</artifactId>
+    		<version>3.1.0</version>
+		</dependency>
+         
         <!-- mgmt-api-java-sdk --> 
     </dependencies>
 

--- a/samples/forecastweatherapi-recommended/src/gateway/shared-pom.xml
+++ b/samples/forecastweatherapi-recommended/src/gateway/shared-pom.xml
@@ -113,6 +113,9 @@
                 <apigee.mfatoken>${mfatoken}</apigee.mfatoken> <!-- optional: mfa -->
                 <apigee.authtype>${authtype}</apigee.authtype> <!-- optional: oauth|basic(default) -->
                 <apigee.bearer>${bearer}</apigee.bearer> <!-- optional: Bearer token override -->
+                <apigee.refresh>${refresh}</apigee.refresh> <!-- optional: Refresh token override -->
+                <apigee.clientid>${clientId}</apigee.clientid> <!-- optional: Oauth Client Id - Default is edgecli-->
+                <apigee.clientsecret>${clientSecret}</apigee.clientsecret> <!-- optional: Oauth Client Secret Default is edgeclisecret-->
                 <!--apigee.override.delay>10</apigee.override.delay-->
                 <!--apigee.delay>1000</apigee.delay-->
             </properties>
@@ -135,6 +138,9 @@
                 <apigee.mfatoken>${mfatoken}</apigee.mfatoken> <!-- optional: mfa -->
                 <apigee.authtype>${authtype}</apigee.authtype> <!-- optional: oauth|basic(default) -->
                 <apigee.bearer>${bearer}</apigee.bearer> <!-- optional: Bearer token override -->
+                <apigee.refresh>${refresh}</apigee.refresh> <!-- optional: Refresh token override -->
+                <apigee.clientid>${clientId}</apigee.clientid> <!-- optional: Oauth Client Id - Default is edgecli-->
+                <apigee.clientsecret>${clientSecret}</apigee.clientsecret> <!-- optional: Oauth Client Secret Default is edgeclisecret-->
                 <!--apigee.override.delay>10</apigee.override.delay-->
                 <!--apigee.delay>1000</apigee.delay-->
             </properties>

--- a/samples/security-sharedflow/src/sharedflows/parent-sharedflow-pom.xml
+++ b/samples/security-sharedflow/src/sharedflows/parent-sharedflow-pom.xml
@@ -113,6 +113,10 @@
                 <apigee.tokenurl>${tokenurl}</apigee.tokenurl> <!-- optional: oauth -->
                 <apigee.mfatoken>${mfatoken}</apigee.mfatoken> <!-- optional: mfa -->
                 <apigee.authtype>${authtype}</apigee.authtype> <!-- optional: oauth|basic(default) -->
+                <apigee.bearer>${bearer}</apigee.bearer> <!-- optional: Bearer token override -->
+                <apigee.refresh>${refresh}</apigee.refresh> <!-- optional: Refresh token override -->
+                <apigee.clientid>${clientId}</apigee.clientid> <!-- optional: Oauth Client Id - Default is edgecli-->
+                <apigee.clientsecret>${clientSecret}</apigee.clientsecret> <!-- optional: Oauth Client Secret Default is edgeclisecret-->
             </properties>
         </profile>
         <profile>
@@ -133,6 +137,10 @@
                 <apigee.tokenurl>${tokenurl}</apigee.tokenurl> <!-- optional: oauth -->
                 <apigee.mfatoken>${mfatoken}</apigee.mfatoken> <!-- optional: mfa -->
                 <apigee.authtype>${authtype}</apigee.authtype> <!-- optional: oauth|basic(default) -->
+                <apigee.bearer>${bearer}</apigee.bearer> <!-- optional: Bearer token override -->
+                <apigee.refresh>${refresh}</apigee.refresh> <!-- optional: Refresh token override -->
+                <apigee.clientid>${clientId}</apigee.clientid> <!-- optional: Oauth Client Id - Default is edgecli-->
+                <apigee.clientsecret>${clientSecret}</apigee.clientsecret> <!-- optional: Oauth Client Secret Default is edgeclisecret-->
             </properties>
         </profile>
     </profiles>

--- a/src/main/java/com/apigee/mgmtapi/sdk/client/MgmtAPIClient.java
+++ b/src/main/java/com/apigee/mgmtapi/sdk/client/MgmtAPIClient.java
@@ -126,6 +126,44 @@ public class MgmtAPIClient {
 		return token;
 
 	}
+	
+	/**
+	 * To get the Access Token from Refresh Token
+	 * 
+	 * @param url
+	 * @param clientId
+	 * @param client_secret
+	 * @param username
+	 * @param password
+	 * @return
+	 * @throws Exception
+	 */
+	public AccessToken getAccessTokenFromRefreshToken(String url, String clientId, String client_secret, String refreshToken) throws Exception {
+		RestTemplate restTemplate = new RestTemplate();
+		HttpHeaders headers = new HttpHeaders();
+		AccessToken token = new AccessToken();
+		ResponseEntity<String> result = null;
+		try {
+			headers.add("Authorization", "Basic "
+					+ new String(Base64.encode((clientId + ":" + client_secret).getBytes()), Charset.forName("UTF-8")));
+			headers.add("Content-Type", "application/x-www-form-urlencoded");
+			MultiValueMap<String, String> map = new LinkedMultiValueMap<String, String>();
+			map.add("refresh_token", refreshToken);
+			map.add("grant_type", "refresh_token");
+			HttpEntity<Object> request = new HttpEntity<Object>(map, headers);
+			result = restTemplate.postForEntity(url, request, String.class);
+			if (result.getStatusCode().equals(HttpStatus.OK)) {
+				Gson gson = new Gson();
+				token = gson.fromJson(result.getBody(), AccessToken.class);
+
+			}
+		} catch (Exception e) {
+			logger.error("Refresh Token could be invalid or expired: "+e.getMessage());
+			throw e;
+		}
+		return token;
+
+	}
 
 	/**
 	 * Fetch the properties from the property file passed as system argument (-DconfigFile.path)
@@ -146,5 +184,4 @@ public class MgmtAPIClient {
 		}
 		return service.getEnvironment();
 	}
-
 }

--- a/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/GatewayAbstractMojo.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/GatewayAbstractMojo.java
@@ -125,11 +125,32 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 	private String orgName;
 	
 	/**
-	 * Gateway host bearer token
+	 * Gateway bearer token
 	 * 
 	 * @parameter expression="${apigee.bearer}"
 	 */
 	private String bearer;
+	
+	/**
+	 * Gateway refresh token
+	 * 
+	 * @parameter expression="${apigee.refresh}"
+	 */
+	private String refresh;
+	
+	/**
+	 * Gateway OAuth clientId
+	 * 
+	 * @parameter expression="${apigee.clientid}"
+	 */
+	private String clientid;
+	
+	/**
+	 * Gateway OAuth clientSecret
+	 * 
+	 * @parameter expression="${apigee.clientsecret}"
+	 */
+	private String clientsecret;
 	
 	/**
 	 * Gateway host username
@@ -212,8 +233,11 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 		this.buildProfile.setAuthType(this.authType);
 		this.buildProfile.setEnvironment(this.deploymentEnv);
 		this.buildProfile.setBearerToken(this.bearer);
+		this.buildProfile.setRefreshToken(this.refresh);
 		this.buildProfile.setCredential_user(this.userName);
 		this.buildProfile.setCredential_pwd(this.password);
+		this.buildProfile.setClientId(this.clientid);
+		this.buildProfile.setClientSecret(this.clientsecret);
 		this.buildProfile.setProfileId(this.id);
 		this.buildProfile.setOptions(this.options);
 		this.buildProfile.setDelay(this.delay);

--- a/src/main/java/io/apigee/buildTools/enterprise4g/rest/RestUtil.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/rest/RestUtil.java
@@ -932,7 +932,7 @@ public class RestUtil {
     
     
     /**
-     * This method is used to validate the Bearer token. It validates the source and the expiration
+     * This method is used to validate the Bearer token. It validates the source and the expiration and if the token is about to expire in 30 seconds, set as invalid token
      * @param accessToken
      * @param profile
      * @param clientId

--- a/src/main/java/io/apigee/buildTools/enterprise4g/rest/RestUtil.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/rest/RestUtil.java
@@ -28,6 +28,10 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.apigee.mgmtapi.sdk.client.MgmtAPIClient;
+import com.apigee.mgmtapi.sdk.model.AccessToken;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.google.api.client.http.FileContent;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpHeaders;
@@ -41,7 +45,6 @@ import com.google.api.client.http.UrlEncodedContent;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson.JacksonFactory;
-import com.google.api.client.testing.http.MockHttpContent;
 import com.google.api.client.util.GenericData;
 import com.google.api.client.util.Key;
 import com.google.gson.Gson;
@@ -50,9 +53,6 @@ import com.google.gson.GsonBuilder;
 import io.apigee.buildTools.enterprise4g.utils.PrintUtil;
 import io.apigee.buildTools.enterprise4g.utils.ServerProfile;
 import io.apigee.buildTools.enterprise4g.utils.StringToIntComparator;
-
-import com.apigee.mgmtapi.sdk.client.MgmtAPIClient;
-import com.apigee.mgmtapi.sdk.model.AccessToken;
 
 public class RestUtil {
 
@@ -68,8 +68,8 @@ public class RestUtil {
     public static final String STATE_IMPORTED = "imported";
 
     static String accessToken = null;
-    static final String mgmtAPIClientId = "edgecli";
-    static final String mgmtAPIClientSecret = "edgeclisecret";
+    //static final String mgmtAPIClientId = "edgecli";
+    //static final String mgmtAPIClientSecret = "edgeclisecret";
 
     public static class Options {
 
@@ -843,7 +843,8 @@ public class RestUtil {
         MgmtAPIClient client = new MgmtAPIClient();
         String mfaToken = profile.getMFAToken();
         String tokenUrl = profile.getTokenUrl();
-
+        String mgmtAPIClientId = (profile.getClientId()!=null && !profile.getClientId().equalsIgnoreCase(""))?profile.getClientId():"edgecli";
+        String mgmtAPIClientSecret = (profile.getClientSecret()!=null && !profile.getClientSecret().equalsIgnoreCase(""))?profile.getClientSecret():"edgeclisecret";
         /**** Basic Auth - Backward compatibility ****/
         if (profile.getAuthType() != null &&
             profile.getAuthType().equalsIgnoreCase("basic")) {
@@ -854,9 +855,45 @@ public class RestUtil {
         }
 
         /**** OAuth ****/
-        if (profile.getBearerToken() != null) {
-            accessToken = profile.getBearerToken();
-            headers.setAuthorization("Bearer " + accessToken);
+        if (profile.getBearerToken() != null && !profile.getBearerToken().equalsIgnoreCase("")){
+        	//Need to validate access token only if refresh token is provided. 
+	        	//If access token is not valid, create a bearer token using the refresh token 
+	        	//If access token is valid, use that 
+        	accessToken = (accessToken!=null)?accessToken:profile.getBearerToken();        	
+        	if(profile.getRefreshToken() != null && !profile.getRefreshToken().equalsIgnoreCase("")){
+        		if(isValidBearerToken(accessToken, profile, mgmtAPIClientId)){
+        			logger.info("Access Token valid");
+        			headers.setAuthorization("Bearer " + accessToken);
+                 }else{
+                	 try{
+                		 AccessToken token = null;
+                		 logger.info("Access token not valid so acquiring new access token using Refresh Token");
+                		 token = client.getAccessTokenFromRefreshToken(
+		     			 			tokenUrl,
+		     			 			mgmtAPIClientId, mgmtAPIClientSecret, 
+		     			 			profile.getRefreshToken());
+                		 logger.info("New Access Token acquired");
+			         	 accessToken = token.getAccess_token();
+			             headers.setAuthorization("Bearer " + accessToken);
+                	 }catch (Exception e) {
+                        logger.error(e.getMessage());
+                        throw new IOException(e.getMessage());
+                     }
+                 }
+        	}
+        	//if refresh token is not passed, validate the access token and use it accordingly
+        	else{
+        		logger.info("Validating the access token passed");
+        		if(isValidBearerToken(profile.getBearerToken(), profile, mgmtAPIClientId)){
+        			logger.info("Access Token valid");
+        			accessToken = profile.getBearerToken();
+                    headers.setAuthorization("Bearer " + accessToken);
+        		}else{
+        			logger.error("Access token not valid");
+        			throw new IOException ("Access token not valid");
+        		}
+        		
+        	}
         }
         else if (accessToken != null) {
             // subsequent calls
@@ -891,5 +928,34 @@ public class RestUtil {
         }
         logger.info(PrintUtil.formatRequest(request));
         return request.execute();
+    }
+    
+    
+    /**
+     * This method is used to validate the Bearer token. It validates the source and the expiration
+     * @param accessToken
+     * @param profile
+     * @param clientId
+     * @return
+     * @throws IOException
+     */
+    private static boolean isValidBearerToken(String accessToken, ServerProfile profile, String clientId) throws IOException{
+    	boolean isValid = false;
+    	try {
+		    JWT jwt = JWT.decode(accessToken);
+		    String jwtClientId = jwt.getClaim("client_id").asString();
+		    String jwtEmailId = jwt.getClaim("email").asString();
+		    long jwtExpiresAt = jwt.getExpiresAt().getTime()/1000;
+		    long difference = jwtExpiresAt - (System.currentTimeMillis()/1000);
+		    if(jwt!= null && jwtClientId!=null && jwtClientId.equals(clientId)
+	    		&& jwtEmailId!=null && jwtEmailId.equals(profile.getCredential_user())
+	    		&& profile.getTokenUrl().contains(jwt.getIssuer())
+	    		&& difference >= 30){
+		    	isValid = true;
+		    }
+		} catch (JWTDecodeException exception){
+		   throw new IOException(exception.getMessage());
+		}
+    	return isValid;
     }
 }

--- a/src/main/java/io/apigee/buildTools/enterprise4g/utils/ServerProfile.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/utils/ServerProfile.java
@@ -25,7 +25,10 @@ public class ServerProfile {
 							// https://api.enterprise.apigee.com
 	private String tokenURL; // Mgmt API OAuth token endpoint
 	private String mfaToken; // Mgmt API OAuth MFA - TOTP
+	private String clientId; //Mgmt API OAuth Client Id (optional)
+	private String clientSecret; //Mgmt API OAuth Client Secret (optional)
 	private String bearerToken; //Mgmt API OAuth Token
+	private String refreshToken; //Mgmt API OAuth Refresh Token
 	private String authType; // Mgmt API Auth Type oauth|basic
 	private String environment; // prod or test
 	private String api_version; // v2 or v1 in the server url
@@ -92,6 +95,22 @@ public class ServerProfile {
 	public void setMFAToken(String otp) {
 		this.mfaToken = otp;
 	}
+	
+	public String getClientId() {
+		return this.clientId;
+	}
+
+	public void setClientId(String clientId) {
+		this.clientId = clientId;
+	}
+	
+	public String getClientSecret() {
+		return this.clientSecret;
+	}
+
+	public void setClientSecret(String clientSecret) {
+		this.clientSecret = clientSecret;
+	}
 
 	public String getBearerToken() {
 		return this.bearerToken;
@@ -99,6 +118,14 @@ public class ServerProfile {
 
 	public void setBearerToken(String token) {
 		this.bearerToken = token;
+	}
+	
+	public String getRefreshToken() {
+		return this.refreshToken;
+	}
+
+	public void setRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
 	}
 
 	public String getApi_type() {

--- a/src/test/java/io/apigee/buildTools/enterprise4g/test/TestGetRevisionWithRefresh.java
+++ b/src/test/java/io/apigee/buildTools/enterprise4g/test/TestGetRevisionWithRefresh.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2016 Apigee Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apigee.buildTools.enterprise4g.test;
+
+import io.apigee.buildTools.enterprise4g.rest.RestUtil;
+import io.apigee.buildTools.enterprise4g.utils.ServerProfile;
+import com.apigee.mgmtapi.sdk.client.MgmtAPIClient;
+import com.apigee.mgmtapi.sdk.model.AccessToken;
+import junit.framework.TestCase;
+
+import java.io.IOException;
+
+public class TestGetRevisionWithRefresh extends TestCase {
+	
+	ServerProfile profile = new ServerProfile();
+	
+	protected void setUp() throws Exception {
+		super.setUp();
+
+        profile.setHostUrl("https://api.enterprise.apigee.com");
+        profile.setApplication("taskservice");
+        profile.setCredential_user(System.getProperty("username"));
+        profile.setCredential_pwd(System.getProperty("password"));
+        profile.setEnvironment(System.getProperty("env"));
+        profile.setOrg(System.getProperty("org"));
+        profile.setApi_version("v1");
+        AccessToken t1 = generateAccessToken();
+        AccessToken t2 = generateAccessTokenFromRefreshToken(t1.getRefresh_token());
+        profile.setBearerToken(t2.getAccess_token());
+        profile.setTokenUrl("https://login.apigee.com/oauth/token");
+
+    }
+	
+	public void testGetRevisionCall() throws IOException{
+		RestUtil.getRevision(profile);
+		System.out.println("revision number::"+ RestUtil.getVersionRevision());
+		assertNotNull(RestUtil.getVersionRevision());
+	}
+	
+    //the client can generate the token using any other plugin they choose
+    private AccessToken generateAccessToken() throws Exception{
+        MgmtAPIClient client = new MgmtAPIClient();
+        AccessToken token = client.getAccessToken(
+                            "https://login.apigee.com/oauth/token",
+                            "edgecli", "edgeclisecret",
+                            System.getProperty("username"),
+                            System.getProperty("password"));
+        return token;
+    }
+    
+  //the client can generate the token using any other plugin they choose
+    private AccessToken generateAccessTokenFromRefreshToken(String refreshToken) throws Exception{
+        MgmtAPIClient client = new MgmtAPIClient();
+        AccessToken token = client.getAccessTokenFromRefreshToken("https://login.apigee.com/oauth/token",
+                "edgecli", "edgeclisecret", refreshToken);
+        return token;
+    }
+
+}

--- a/src/test/java/io/apigee/buildTools/enterprise4g/test/deploymentTestSuite.java
+++ b/src/test/java/io/apigee/buildTools/enterprise4g/test/deploymentTestSuite.java
@@ -29,6 +29,7 @@ public class deploymentTestSuite {
 		suite.addTestSuite(TestRefreshBundle.class);
         suite.addTestSuite(TestDeleteDeployedBundle.class);
 		suite.addTestSuite(TestGetRevisionWithBearer.class);
+		suite.addTestSuite(TestGetRevisionWithRefresh.class);
 		//$JUnit-END$
 		return suite;
 	}


### PR DESCRIPTION
Plugin extended support for refresh token

You can now pass refresh token along with bearer token. If the bearer token is not valid (or about to expire in 30 seconds), we use the refresh token to generate a new access token