### PR TITLE
Allow proxy name to be configured by mvn parameter

### DIFF
--- a/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/GatewayAbstractMojo.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/GatewayAbstractMojo.java
@@ -65,7 +65,13 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 	 * @parameter expression="${apigee.profile}"
 	 */
 	private String id;
-	
+
+	/**
+	 * Proxy Name
+	 *
+	 * @parameter expression="${apigee.proxyname}" default-value="${project.name}"
+	 */
+	private String proxyName;
 
 	/**
 	 * Gateway host URL
@@ -224,7 +230,7 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 	public ServerProfile getProfile() {
 		this.buildProfile = new ServerProfile();
 		this.buildProfile.setOrg(this.orgName);
-		this.buildProfile.setApplication(this.projectName);
+		this.buildProfile.setApplication(this.proxyName);
 		this.buildProfile.setApi_version(this.apiVersion);
 		this.buildProfile.setApi_type(this.apiType);
 		this.buildProfile.setHostUrl(this.hostURL);
@@ -259,7 +265,7 @@ public abstract class GatewayAbstractMojo extends AbstractMojo {
 	}
 
 	public String getApplicationBundlePath() {
-		return this.baseDirectory+File.separator+"target"+File.separator+this.projectName+"-"+this.projectVersion+".zip";
+		return this.baseDirectory+File.separator+"target"+File.separator+this.proxyName+"-"+this.projectVersion+".zip";
 	}
 	
 	public String getBaseDirectoryPath(){


### PR DESCRIPTION
Hi team,

This pull requests aims to address [issue 38](https://github.com/apigee/apigee-deploy-maven-plugin/issues/38) by allowing the proxy name to be configured by a mvn parameter, defaulting to `project.name` if not set.

Example:

```
     <profile>
            <id>prod</id>
            <properties>
                <org>my-org</org>  
                <apigee.profile>prod</apigee.profile>
                <apigee.env>prod</apigee.env>
                <apigee.proxyname>my-service-sandbox</apigee.proxyname>
...
``` 

Thanks


