### PR TITLE
Added activation feature on override flag

### DIFF
--- a/samples/forecastweatherapi-recommended/src/gateway/forecastweatherapi/apiproxy/policies/Assign-Message-1.xml
+++ b/samples/forecastweatherapi-recommended/src/gateway/forecastweatherapi/apiproxy/policies/Assign-Message-1.xml
@@ -3,7 +3,8 @@
     <DisplayName>Assign Message 1</DisplayName>
     <Set>
         <Headers>
-          <Header name="ENV">ENVIRONMENT</Header>  
+          <Header name="ENV">ENVIRONMENT</Header>
+          <Header name="X-Debug-Mode"/>
         </Headers>
         <QueryParams/>
         <FormParams/>

--- a/samples/forecastweatherapi-recommended/src/gateway/forecastweatherapi/apiproxy/proxies/default.xml
+++ b/samples/forecastweatherapi-recommended/src/gateway/forecastweatherapi/apiproxy/proxies/default.xml
@@ -27,6 +27,10 @@
         <VirtualHost>default</VirtualHost>
         <VirtualHost>secure</VirtualHost>
     </HTTPProxyConnection>
+    <RouteRule name="demo-server">
+        <TargetEndpoint>demo-server</TargetEndpoint>
+        <Condition>proxy.pathsuffix MatchesPath &quot;/api/**&quot;</Condition>
+    </RouteRule>
     <RouteRule name="default">
         <TargetEndpoint>default</TargetEndpoint>
     </RouteRule>

--- a/samples/forecastweatherapi-recommended/src/gateway/forecastweatherapi/apiproxy/targets/demo-server.xml
+++ b/samples/forecastweatherapi-recommended/src/gateway/forecastweatherapi/apiproxy/targets/demo-server.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<TargetEndpoint name="demo-server">
+    <Description/>
+    <Flows/>
+    <PreFlow name="PreFlow">
+        <Request/>
+        <Response/>
+    </PreFlow>
+    <HTTPTargetConnection>
+        <LoadBalancer>
+            <Server name="replace-me"/>
+        </LoadBalancer>
+    </HTTPTargetConnection>
+    <PostFlow name="PostFlow">
+        <Request/>
+        <Response/>
+    </PostFlow>
+</TargetEndpoint>

--- a/samples/forecastweatherapi-recommended/src/gateway/forecastweatherapi/config.json
+++ b/samples/forecastweatherapi-recommended/src/gateway/forecastweatherapi/config.json
@@ -9,6 +9,12 @@
                         {
                             "xpath": "/AssignMessage/Set/Headers/Header[@name='ENV']",
                             "value": "TEST"
+                        },
+                        {
+                            "xpath": "/AssignMessage/Set/Headers/Header[@name='X-Debug-Mode']",
+                            "mode": "replace_element",
+                            // remove X-Debug-Mode for test env
+                            "value": "<Header name='X-Production-Mode'/>"
                         }
                     ]
                 }
@@ -18,8 +24,15 @@
                     "name": "default.xml",
                     "tokens": [
                         {
+                            // "mode": "replace_value", // default
                             "xpath": "/ProxyEndpoint/HTTPProxyConnection/BasePath",
                             "value": "/weatherapi"
+                        },
+                        {
+                            "xpath": "/ProxyEndpoint/HTTPProxyConnection",
+                            // appends the below XML as is to the HTTPProxyConnection element in default.xml
+                            "mode": "append",
+                            "value": "<VirtualHost>demo-host</VirtualHost>"
                         }
                     ]
                 }
@@ -67,6 +80,20 @@
                         {
                             "xpath": "/TargetEndpoint/HTTPTargetConnection/URL",
                             "value": "http://weather.yahooapis.com"
+                        }
+                    ]
+                },
+                {
+                    "name": "demo-server.xml",
+                    "tokens": [
+                        {
+                            "xpath": "/TargetEndpoint/HTTPTargetConnection/LoadBalancer/Server[@name='replace-me']",
+                            "mode": "replace_element",
+                            // to support multiple services with different targetServers that share the proxy code
+                            // usually the case when working with multiple environments, lower envs can share targets
+                            // but PROD uses specific targets
+                            // replaces the below XML as is to the HTTPTargetConnection LoadBalancer element in demo-server.xml
+                            "value": "<Server name=\"api-v0\"/>"
                         }
                     ]
                 }

--- a/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/DeployMojo.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/DeployMojo.java
@@ -127,6 +127,9 @@ public class DeployMojo extends GatewayAbstractMojo
 						break;
 					case override:
 						Options.override=true;
+						if (this.getRevision() != null) {
+							revisionInArg = String.valueOf(this.getRevision());
+						}
 						break;
 					default:
 						break;	
@@ -221,23 +224,31 @@ public class DeployMojo extends GatewayAbstractMojo
 		} 
 		
 	}
-	
+
 	/**
 	 * Activate a bundle revision.
 	 */
-	
-	public void doActivateBundle()  throws IOException, MojoFailureException{
+
+	public void doActivateBundle(String revision)  throws IOException, MojoFailureException{
 		try {
 			logger.info("\n\n=============Activating Bundle================\n\n");
 			state = State.ACTIVATING;
-			RestUtil.activateBundleRevision(super.getProfile(), this.bundleRevision);
+			RestUtil.activateBundleRevision(super.getProfile(), revision);
 
 		} catch (IOException e) {
 			throw e ;
 		} catch (RuntimeException e) {
 			throw e;
-		} 
-		
+		}
+
+	}
+
+	/**
+	 * Activate a bundle revision.
+	 */
+	
+	public void doActivateBundle()  throws IOException, MojoFailureException{
+		doActivateBundle(this.bundleRevision);
 	}
 	
 	/**
@@ -278,6 +289,17 @@ public class DeployMojo extends GatewayAbstractMojo
 				case NULL:
 
 						if (Options.override) {
+
+							// If revision to be overridden is passed in the maven command as an argument, only override
+							// and activate that revision
+							if(revisionInArg.length()>0){
+								logger.info("Overriding to Revision passed: "+ revisionInArg);
+								doActivateBundle(revisionInArg);
+								break;
+							}
+
+							// else import and create a new revision, if there is no existing active revision for given env,
+							// treat as simple import-activate
                             activeRevision=RestUtil.getDeployedRevision(this.getProfile());
                             if (activeRevision.length() > 0) {
                                 doImport();

--- a/src/main/java/io/apigee/buildTools/enterprise4g/utils/ConfigTokens.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/utils/ConfigTokens.java
@@ -101,11 +101,25 @@ public class ConfigTokens { // represents configuration files containing all
 
 	public class Token {
 
+		public static final String MODE_APPEND = "append";
+		public static final String MODE_REPLACE_VALUE = "replace_value";
+		public static final String MODE_REPLACE_ELEMENT = "replace_element";
 		@Key
 		public String xpath;
 
 		@Key
 		public String value;
+
+		@Key
+		public String mode = MODE_REPLACE_VALUE;
+
+		public String getMode() {
+			return mode;
+		}
+
+		public void setMode(String mode) {
+			this.mode = mode;
+		}
 
 		public String getXpath() {
 			return xpath;


### PR DESCRIPTION
- added support for proxy activation if override with revision number is provided on
proxy deploy maven command
- Added support for multiple config token replacement modes for fine
control of proxy modification during deployment runs
- MODE_APPEND = append; appends an element inside the given xpath
element as a child node. Expects XML string as config.json token value,
Errors when SAXExceptions occurs and build fails
- MODE_REPLACE_ELEMENT = replace_element; replaces the complete element
expects XML string in config.json as token value, deletes if null or
empty value is provided. defaults to replace_value upon SAXExceptions
- MODE_REPLACE_VALUE = replace_value; default mode replaces value for
given xpath element