### PR TITLE
Add source/target properties to POM files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,8 @@
 
 	<!-- mgmt-api-java-sdk -->
 	<properties>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.version>4.3.20.RELEASE</spring.version>
 		<spring.security.version>4.2.9.RELEASE</spring.security.version>
@@ -157,6 +159,7 @@
 						</goals>
 						<configuration> <!-- add this to disable checking -->
 							<additionalparam>-Xdoclint:none</additionalparam>
+							<source>8</source>
 						</configuration>
 					</execution>
 				</executions>
@@ -416,6 +419,9 @@
 								<goals>
 									<goal>jar</goal>
 								</goals>
+								<configuration>
+									<source>8</source>
+								</configuration>
 							</execution>
 						</executions>
 					</plugin>


### PR DESCRIPTION
The build fails if you try to compile with JDK14.
I suspect, the same happens with any JDK greater than 8.

I added these properties to be able to build with newer JDK.