### PR TITLE
Add apigee.options=async

### DIFF
--- a/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/DeployMojo.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/mavenplugin/DeployMojo.java
@@ -59,7 +59,7 @@ public class DeployMojo extends GatewayAbstractMojo
 	}
 	
 	enum OPTIONS {
-		override
+		override,async
 	}
 	
 	State state = State.START;
@@ -105,13 +105,16 @@ public class DeployMojo extends GatewayAbstractMojo
 			if (options != null) {
 				String [] opts = options.split(",");
 				for (String opt : opts) {
+					opt = opt.replace("-", "");
 					switch (OPTIONS.valueOf(opt)) {
 					case override:
 						Options.override=true;
 						break;
+					case async:
+						Options.async=true;
+						break;
 					default:
-						break;	
-					
+						break;
 					}
 				}
 			}
@@ -213,6 +216,12 @@ public class DeployMojo extends GatewayAbstractMojo
 			logger.info("\n\n=============Activating Bundle================\n\n");
 			state = State.ACTIVATING;
 			String revision = RestUtil.activateBundleRevision(super.getProfile(), this.bundleRevision);
+
+			// if user passed -Dapigee.options=async, no need for polling, exit early
+			if (Options.async) {
+				return;
+			}
+
 			boolean deployed = false;
 			//Loop to check the deployment status
 			for (; !deployed; ) {

--- a/src/main/java/io/apigee/buildTools/enterprise4g/rest/RestUtil.java
+++ b/src/main/java/io/apigee/buildTools/enterprise4g/rest/RestUtil.java
@@ -78,6 +78,7 @@ public class RestUtil {
         public static boolean update;
         public static boolean inactive;
         public static boolean override;
+        public static boolean async;
         public static boolean validate;
         public static long delay;
         public static long override_delay;


### PR DESCRIPTION
This flag allows the user to deploy the API proxy, but not have to wait
for the proxy status to show as running.

This is useful if you want deploy proxies in batch, and monitor the
deployment state concurrently outside of the maven deploy plugin

To use this flag, you can pass it like this:

-Dapigee.options=async