### PR TITLE
doc(README.md): link to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The code is distributed under the Apache License 2.0.
 TL;DR
 ------------
 
-The [samples folder](https://github.com/apigee/apigee-deploy-maven-plugin/tree/hybrid/samples) provides a Readme with Getting Started steps and commands to hit the ground quickly.
+The [samples folder](https://github.com/apigee/apigee-deploy-maven-plugin/tree/main/samples) provides a Readme with Getting Started steps and commands to hit the ground quickly.
 
 ------------
 Video


### PR DESCRIPTION
Link to main branch

## Reasons:
* "/samples" in the [main branch](https://github.com/apigee/apigee-deploy-maven-plugin/tree/main/samples) are more recent that [hybrid branch](https://github.com/apigee/apigee-deploy-maven-plugin/tree/hybrid/samples) -> NOT sense to hit specific branch in the README.md of the main branch
 

## How to review?
* Check that "/samples" in the [main branch](https://github.com/apigee/apigee-deploy-maven-plugin/tree/main/samples) are more recent that [hybrid branch](https://github.com/apigee/apigee-deploy-maven-plugin/tree/hybrid/samples) 
* Open in your browser or your desired way, the url "https://github.com/apigee/apigee-deploy-maven-plugin/tree/main/samples" checking, that it's valid one